### PR TITLE
Add `minimize` option to probability_vs_all (lower-is-better support)

### DIFF
--- a/cprior/cdist/beta.py
+++ b/cprior/cdist/beta.py
@@ -54,6 +54,17 @@ def func_mv_prob(x, a, b, variant_params):
     return np.exp(pdf) * g
 
 
+def func_mv_prob_min(x, a, b, variant_params):
+    """Integrand for P(variant is the minimum).
+
+    Mirror of ``func_mv_prob`` using the survival function (1 - CDF) so the
+    product is P(all others >= x) instead of P(all others <= x).
+    """
+    pdf = (a - 1) * np.log(x) + (b - 1) * np.log(1 - x) - special.betaln(a, b)
+    g = np.prod([1.0 - special.betainc(a, b, x) for a, b in variant_params], axis=0)
+    return np.exp(pdf) * g
+
+
 def func_mv_el(x, a, b, variant_params):
     """Integrand expected loss integral."""
     n = len(variant_params)
@@ -744,7 +755,7 @@ class BetaMVTest(BayesMVTest):
             return (x1 > x0 + lift).mean()
 
     def probability_vs_all(self, method="quad", variant="B", lift=0,
-                           mlhs_samples=1000):
+                           mlhs_samples=1000, minimize=False):
         r"""
         Compute the error probability or *chance to beat all* variations. For
         example, given variants "A", "B", "C" and "D", and choosing
@@ -769,6 +780,12 @@ class BetaMVTest(BayesMVTest):
         mlhs_samples : int (default=1000)
             Number of samples for MLHS method.
 
+        minimize : bool (default=False)
+            If True compute the *chance to be the minimum* instead, i.e.
+            :math:`P[B < \min(A, C, D) - lift]`. Use this for "lower is better"
+            KPIs (e.g. churn / cancellation rate), where the winning variant is
+            the smallest rather than the largest.
+
         Returns
         -------
         probability_vs_all : float
@@ -790,8 +807,12 @@ class BetaMVTest(BayesMVTest):
             processes = [pool.apply_async(self._rvs, args=(v, ))
                          for v in variants]
             xall = [p.get() for p in processes]
-            maxall = np.maximum.reduce(xall)
 
+            if minimize:
+                minall = np.minimum.reduce(xall)
+                return (xvariant < minall - lift).mean()
+
+            maxall = np.maximum.reduce(xall)
             return (xvariant > maxall + lift).mean()
         elif method == "quad":
             # prepare parameters
@@ -803,7 +824,8 @@ class BetaMVTest(BayesMVTest):
 
             points = get_integration_points(a, b)
 
-            return integrate.quad(func=func_mv_prob, a=0, b=1, points=points, args=(
+            func = func_mv_prob_min if minimize else func_mv_prob
+            return integrate.quad(func=func, a=0, b=1, points=points, args=(
                 a, b, variant_params))[0]
         else:
             # prepare parameters
@@ -815,8 +837,10 @@ class BetaMVTest(BayesMVTest):
             v = (r - 0.5) / mlhs_samples
             x = self.models[variant].ppf(v)
 
-            return np.mean(np.prod([special.betainc(a, b, x)
-                           for a, b in variant_params], axis=0))
+            cdfs = [special.betainc(a, b, x) for a, b in variant_params]
+            if minimize:
+                return np.mean(np.prod([1.0 - cdf for cdf in cdfs], axis=0))
+            return np.mean(np.prod(cdfs, axis=0))
 
     def expected_loss(self, method="exact", control="A", variant="B", lift=0,
                       mlhs_samples=10000):

--- a/cprior/cdist/gamma.py
+++ b/cprior/cdist/gamma.py
@@ -36,6 +36,18 @@ def func_mv_prob(x, a, b, variant_params):
     return np.exp(pdf) * g
 
 
+def func_mv_prob_min(x, a, b, variant_params):
+    """Integrand for P(variant is the minimum).
+
+    Mirror of ``func_mv_prob`` using the survival function (upper incomplete
+    gamma) so the product is P(all others >= x) instead of P(all others <= x).
+    """
+    pdf = a * np.log(b) + (a - 1) * np.log(x) - b * x - special.gammaln(a)
+    g = np.prod([special.gammaincc(a, b * x) for a, b in variant_params],
+                axis=0)
+    return np.exp(pdf) * g
+
+
 def func_mv_el(x, a, b, variant_params):
     """Integrand expected loss integral."""
     n = len(variant_params)
@@ -663,7 +675,7 @@ class GammaMVTest(BayesMVTest):
             return (x1 > x0 + lift).mean()
 
     def probability_vs_all(self, method="quad", variant="B", lift=0,
-                           mlhs_samples=1000):
+                           mlhs_samples=1000, minimize=False):
         r"""
         Compute the error probability or *chance to beat all* variations. For
         example, given variants "A", "B", "C" and "D", and choosing
@@ -688,6 +700,12 @@ class GammaMVTest(BayesMVTest):
         mlhs_samples : int (default=1000)
             Number of samples for MLHS method.
 
+        minimize : bool (default=False)
+            If True compute the *chance to be the minimum* instead, i.e.
+            :math:`P[B < \min(A, C, D) - lift]`. Use this for "lower is better"
+            KPIs, where the winning variant is the smallest rather than the
+            largest.
+
         Returns
         -------
         probability_vs_all : float
@@ -709,8 +727,12 @@ class GammaMVTest(BayesMVTest):
             processes = [pool.apply_async(self._rvs, args=(v, ))
                          for v in variants]
             xall = [p.get() for p in processes]
-            maxall = np.maximum.reduce(xall)
 
+            if minimize:
+                minall = np.minimum.reduce(xall)
+                return (xvariant < minall - lift).mean()
+
+            maxall = np.maximum.reduce(xall)
             return (xvariant > maxall + lift).mean()
         elif method == "quad":
             # prepare parameters
@@ -721,7 +743,8 @@ class GammaMVTest(BayesMVTest):
             b = self.models[variant].rate_posterior
 
             n = self.models[variant].ppf(0.99999999)
-            return integrate.quad(func=func_mv_prob, a=0, b=n, args=(
+            func = func_mv_prob_min if minimize else func_mv_prob
+            return integrate.quad(func=func, a=0, b=n, args=(
                 a, b, variant_params))[0]
         else:
             # prepare parameters
@@ -733,8 +756,10 @@ class GammaMVTest(BayesMVTest):
             v = (r - 0.5) / mlhs_samples
             x = self.models[variant].ppf(v)
 
-            return np.nanmean(np.prod([special.gammainc(a, b * x)
-                              for a, b in variant_params], axis=0))
+            cdfs = [special.gammainc(a, b * x) for a, b in variant_params]
+            if minimize:
+                return np.nanmean(np.prod([1.0 - cdf for cdf in cdfs], axis=0))
+            return np.nanmean(np.prod(cdfs, axis=0))
 
     def expected_loss(self, method="exact", control="A", variant="B", lift=0):
         r"""

--- a/cprior/cdist/normal_inverse_gamma.py
+++ b/cprior/cdist/normal_inverse_gamma.py
@@ -73,6 +73,21 @@ def func_mv_prob_mean(x, mu, s, v, variant_params):
     return pdf * cdf
 
 
+def func_mv_prob_mean_min(x, mu, s, v, variant_params):
+    """Integrand for P(variant mean is the minimum).
+
+    Mirror of ``func_mv_prob_mean`` using the Student-t survival function
+    (1 - CDF) so the product is P(all other means >= x).
+    """
+    t = (x - mu) / s
+    pdf = np.exp(-0.5 * (1 + v) * np.log(1 + t ** 2 / v)
+                 - 0.5 * np.log(v) - np.log(s) - special.betaln(v * 0.5, 0.5))
+
+    sf = np.prod([1.0 - special.stdtr(2 * a, (x - mu) / np.sqrt(b / a / la))
+                  for (mu, la, a, b) in variant_params], axis=0)
+    return pdf * sf
+
+
 def func_mv_prob_var(x, a, b, variant_params):
     """Integratnd probability integral."""
     pdf = np.exp(a * np.log(b) - (a + 1) * np.log(x) - b / x
@@ -1303,7 +1318,7 @@ class NormalInverseGammaMVTest(BayesMVTest):
             return (x1 > x0 + lift).mean(), (sig21 > sig20 + lift).mean()
 
     def probability_vs_all(self, method="quad", variant="B", lift=0,
-                           mlhs_samples=1000):
+                           mlhs_samples=1000, minimize=False):
         r"""
         Compute the error probability or *chance to beat all* variations. For
         example, given variants "A", "B", "C" and "D", and choosing
@@ -1328,6 +1343,13 @@ class NormalInverseGammaMVTest(BayesMVTest):
         mlhs_samples : int (default=1000)
             Number of samples for MLHS method.
 
+        minimize : bool (default=False)
+            If True compute the *chance the mean is the minimum* instead, i.e.
+            :math:`P[B < \min(A, C, D) - lift]`. Use this for "lower is better"
+            KPIs, where the winning variant has the smallest mean. Only the mean
+            (location) probability is reversed; the variance probability is
+            unaffected.
+
         Returns
         -------
         probability_vs_all : tuple of floats
@@ -1350,8 +1372,12 @@ class NormalInverseGammaMVTest(BayesMVTest):
                          for v in variants]
 
             xall = [p.get() for p in processes]
-            maxall = np.maximum.reduce(xall)
 
+            if minimize:
+                minall = np.minimum.reduce(xall)
+                return (xvariant < minall - lift).mean(axis=0)
+
+            maxall = np.maximum.reduce(xall)
             return (xvariant > maxall + lift).mean(axis=0)
         else:
             # prepare parameters
@@ -1374,8 +1400,10 @@ class NormalInverseGammaMVTest(BayesMVTest):
                 min_t, max_t = stats.t(df=v, loc=mu, scale=s).ppf(
                     [0.00000001, 0.99999999])
 
+                func_mean = func_mv_prob_mean_min if minimize \
+                    else func_mv_prob_mean
                 prob_mean = integrate.quad(
-                    func=func_mv_prob_mean, a=min_t, b=max_t, args=(
+                    func=func_mean, a=min_t, b=max_t, args=(
                         mu, s, v, variant_params))[0]
 
                 # variance
@@ -1393,9 +1421,13 @@ class NormalInverseGammaMVTest(BayesMVTest):
                 # mean
                 x = stats.t(df=2 * a, loc=mu, scale=np.sqrt(b / a / la)).ppf(r)
 
-                prob_mean = np.nanmean(
-                    np.prod([special.stdtr(2*a, (x - mu) / np.sqrt(b / a / la))
-                            for mu, la, a, b in variant_params], axis=0))
+                mean_cdfs = [special.stdtr(2*a, (x - mu) / np.sqrt(b / a / la))
+                             for mu, la, a, b in variant_params]
+                if minimize:
+                    prob_mean = np.nanmean(
+                        np.prod([1.0 - cdf for cdf in mean_cdfs], axis=0))
+                else:
+                    prob_mean = np.nanmean(np.prod(mean_cdfs, axis=0))
 
                 # variance
                 x = stats.invgamma(a=a, scale=b).ppf(r)

--- a/cprior/models/normal_adjusted.py
+++ b/cprior/models/normal_adjusted.py
@@ -230,7 +230,8 @@ class NormalAdjustedMVTest(NormalMVTest):
                 return elr_mean
 
     def probability_vs_all(
-            self, method: str = "quad", variant: str = "B", lift: float = 0, mlhs_samples: int = 1000
+            self, method: str = "quad", variant: str = "B", lift: float = 0, mlhs_samples: int = 1000,
+            minimize: bool = False
     ) -> float:
         """
         Compute the probability of a variant outperforming all other variants by a given lift.
@@ -246,13 +247,17 @@ class NormalAdjustedMVTest(NormalMVTest):
             The amount of uplift.
         mlhs_samples : int, optional (default=1000)
             Number of samples for MLHS method.
+        minimize : bool, optional (default=False)
+            If True compute the chance the variant mean is the *minimum* of all
+            variants. Use this for "lower is better" KPIs.
 
         Returns
         -------
         float
             The probability of the variant outperforming all other variants by the given lift.
         """
-        return super().probability_vs_all(method=method, variant=variant, lift=lift, mlhs_samples=mlhs_samples)[0]
+        return super().probability_vs_all(method=method, variant=variant, lift=lift,
+                                           mlhs_samples=mlhs_samples, minimize=minimize)[0]
 
     def expected_loss_vs_all(
             self, method: str = "quad", variant: str = "B", lift: float = 0, mlhs_samples: int = 1000

--- a/tests/test_beta.py
+++ b/tests/test_beta.py
@@ -441,6 +441,43 @@ def test_beta_mv_probability_vs_all():
         method="MC", variant="B") == approx(0.5996839676, rel=1e-1)
 
 
+def test_beta_mv_probability_vs_all_minimize():
+    models = {
+        "A": BetaModel(alpha=40, beta=600),
+        "B": BetaModel(alpha=70, beta=900),
+        "C": BetaModel(alpha=100, beta=1400)
+    }
+
+    mvtest = BetaMVTest(models, 1000000, 42)
+
+    # P(variant is the minimum) - "lower is better" direction
+    assert mvtest.probability_vs_all(
+        method="quad", variant="A", minimize=True) == approx(
+            0.5890749491, rel=1e-8)
+    assert mvtest.probability_vs_all(
+        method="MLHS", variant="A", minimize=True) == approx(
+            0.5890749491, rel=1e-2)
+    assert mvtest.probability_vs_all(
+        method="MC", variant="A", minimize=True) == approx(
+            0.5890749491, rel=1e-1)
+
+    # P(is min) over all variants must sum to 1
+    p_min = [mvtest.probability_vs_all(method="quad", variant=v, minimize=True)
+             for v in models]
+    assert sum(p_min) == approx(1.0, rel=1e-6)
+
+
+def test_beta_mv_probability_vs_all_minimize_two_variants():
+    # For two variants, P(B is min) == 1 - P(B is max) exactly.
+    mvtest = BetaMVTest(
+        {"A": BetaModel(alpha=40, beta=600), "B": BetaModel(alpha=70, beta=900)},
+        1000000, 42)
+
+    p_max = mvtest.probability_vs_all(method="quad", variant="B")
+    p_min = mvtest.probability_vs_all(method="quad", variant="B", minimize=True)
+    assert p_min == approx(1.0 - p_max, rel=1e-6)
+
+
 def test_beta_mv_expected_loss():
     modelA = BetaModel(alpha=40, beta=60)
     modelB = BetaModel(alpha=70, beta=90)

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -251,6 +251,40 @@ def test_gamma_mv_probability_vs_all():
         method="MC", variant="B") == approx(0.1969431392, rel=1e-1)
 
 
+def test_gamma_mv_probability_vs_all_minimize():
+    models = {
+        "A": GammaModel(shape=25, rate=10000),
+        "B": GammaModel(shape=30, rate=10000),
+        "C": GammaModel(shape=40, rate=11000)
+    }
+
+    mvtest = GammaMVTest(models, 1000000, 42)
+
+    # P(variant is the minimum) - "lower is better" direction. A has the
+    # smallest mean (25/10000) so it is most likely to be the minimum.
+    assert mvtest.probability_vs_all(
+        method="quad", variant="A", minimize=True) == approx(
+            0.7288992798, rel=1e-8)
+    assert mvtest.probability_vs_all(
+        method="MLHS", variant="A", minimize=True) == approx(
+            0.7288992798, rel=1e-2)
+
+    p_min = [mvtest.probability_vs_all(method="quad", variant=v, minimize=True)
+             for v in models]
+    assert sum(p_min) == approx(1.0, rel=1e-6)
+
+
+def test_gamma_mv_probability_vs_all_minimize_two_variants():
+    # For two variants, P(B is min) == 1 - P(B is max) exactly.
+    mvtest = GammaMVTest(
+        {"A": GammaModel(shape=25, rate=10000),
+         "B": GammaModel(shape=30, rate=10000)}, 1000000, 42)
+
+    p_max = mvtest.probability_vs_all(method="quad", variant="B")
+    p_min = mvtest.probability_vs_all(method="quad", variant="B", minimize=True)
+    assert p_min == approx(1.0 - p_max, rel=1e-6)
+
+
 def test_gamma_mv_expected_loss():
     modelA = GammaModel(shape=2500, rate=1000000)
     modelB = GammaModel(shape=3000, rate=1000000)

--- a/tests/test_normal_inverse_gamma.py
+++ b/tests/test_normal_inverse_gamma.py
@@ -391,6 +391,40 @@ def test_normal_inverse_gamma_mv_probability_vs_all():
         (0.1703097379, 0.9576994541), rel=1e-1)
 
 
+def test_normal_inverse_gamma_mv_probability_vs_all_minimize():
+    models = {
+        "A": NormalInverseGammaModel(loc=5.5, variance_scale=3, shape=14,
+                                     scale=5),
+        "B": NormalInverseGammaModel(loc=6.0, variance_scale=4, shape=12,
+                                     scale=9),
+        "C": NormalInverseGammaModel(loc=6.5, variance_scale=4, shape=13,
+                                     scale=4)
+    }
+
+    mvtest = NormalInverseGammaMVTest(models, 1000000)
+
+    # P(mean is the minimum) - "lower is better" direction. A has the smallest
+    # loc (5.5) so it is most likely to have the minimum mean. Only the mean
+    # (first element) is reversed; the variance probability is unchanged.
+    mean_min, var = mvtest.probability_vs_all(
+        method="quad", variant="A", minimize=True)
+    assert mean_min == approx(0.8048234320, rel=1e-8)
+
+    assert mvtest.probability_vs_all(
+        method="MLHS", variant="A", minimize=True)[0] == approx(
+            0.8048234320, rel=1e-2)
+
+    # variance probability is identical with and without minimize
+    assert mvtest.probability_vs_all(method="quad", variant="B")[1] == approx(
+        mvtest.probability_vs_all(
+            method="quad", variant="B", minimize=True)[1], rel=1e-8)
+
+    # P(mean is min) over all variants sums to 1
+    p_min_mean = [mvtest.probability_vs_all(
+        method="quad", variant=v, minimize=True)[0] for v in models]
+    assert sum(p_min_mean) == approx(1.0, rel=1e-6)
+
+
 def test_normal_inverse_gamma_mv_expected_loss():
     modelA = NormalInverseGammaModel(loc=5.5, variance_scale=3, shape=14,
                                      scale=5)


### PR DESCRIPTION
## Why

`probability_vs_all` only computed **P(variant is the maximum)**. For "lower is better" KPIs (churn, cancellation, error rates) the winning variant is the one with the *smallest* value. The naive `100 - P(is max)` only equals `P(is min)` for two variants — for 3+ it is **P(not the max)**, which overstates the chance of being best.

## What

Adds a `minimize=False` parameter to `probability_vs_all` on:
- `BetaMVTest` (rates / Bernoulli)
- `GammaMVTest` (continuous ≥0; also used by `PoissonMVTest`)
- `NormalInverseGammaMVTest` / `NormalAdjustedMVTest` (continuous incl. negatives)

When `minimize=True` it computes **P(variant is the minimum)** directly:
- **quad / MLHS:** survival product `(1 - CDF)` instead of the CDF product (new `func_mv_prob_min` integrands; Student-t survival on the mean for the normal model).
- **MC:** `min`-reduce + `<` comparison instead of `max`/`>`.

For the normal model only the mean (location) direction is reversed; the variance probability is unchanged.

## Verification

New tests in `test_beta.py`, `test_gamma.py`, `test_normal_inverse_gamma.py` assert:
- **2-variant:** `minimize` result == `1 - P(max)` exactly
- **3-variant:** `P(is min)` sums to 1 across variants
- the lowest-mean/rate variant has the highest `P(is min)`
- `quad` ≈ `MLHS` ≈ `MC`

Existing max-direction paths are unchanged (byte-identical), so no behavior change when `minimize=False`.