### PR TITLE
Add `minimize` option to expected_loss_vs_all (lower-is-better support)

### DIFF
--- a/cprior/cdist/beta.py
+++ b/cprior/cdist/beta.py
@@ -82,6 +82,29 @@ def func_mv_el(x, a, b, variant_params):
     return s * (p - q)
 
 
+def func_mv_el_min(x, a, b, variant_params):
+    """Integrand expected loss integral for the *minimum* direction.
+
+    Mirror of ``func_mv_el``: the others' product uses the survival function
+    (so it is the density of the MIN of the others), and the per-variant loss
+    term uses E[max(V - x, 0)] = E[max(x - V, 0)] + (E[V] - x).
+    """
+    n = len(variant_params)
+
+    aa, bb = map(np.array, zip(*variant_params))
+
+    pdf = np.exp((aa - 1) * np.log(x) + (bb - 1) * np.log(1 - x)
+                 - special.betaln(aa, bb))
+
+    s = np.dot(pdf, [np.prod([1.0 - special.betainc(aa[j], bb[j], x)
+               for j in range(n) if j != i], axis=0) for i in range(n)])
+
+    p = x * special.betainc(a, b, x)
+    q = a / (a + b) * special.betainc(a + 1, b, x)
+    mean_v = a / (a + b)
+    return s * (p - q + mean_v - x)
+
+
 def func_mv_elr(x, variant_params):
     """Integrand expected loss relative integral."""
     n = len(variant_params)
@@ -1219,7 +1242,7 @@ class BetaMVTest(BayesMVTest):
                 return ppfl - 1, ppfu - 1
 
     def expected_loss_vs_all(self, method="quad", variant="B", lift=0,
-                             mlhs_samples=1000):
+                             mlhs_samples=1000, minimize=False):
         r"""
         Compute the expected loss against all variations. For example, given
         variants "A", "B", "C" and "D", and choosing variant="B", we compute
@@ -1244,6 +1267,11 @@ class BetaMVTest(BayesMVTest):
         mlhs_samples : int (default=1000)
             Number of samples for MLHS method.
 
+        minimize : bool (default=False)
+            If True compute the loss against the *minimum* of all variations,
+            :math:`\mathrm{E}[\max(B - \min(A, C, D), 0)]` — the expected loss
+            for "lower is better" KPIs. Only "MC" and "quad" are supported.
+
         Returns
         -------
         expected_loss_vs_all : float
@@ -1251,6 +1279,9 @@ class BetaMVTest(BayesMVTest):
         check_mv_method(method=method, method_options=("MC", "MLHS", "quad"),
                         control=None, variant=variant,
                         variants=self.models.keys(), lift=lift)
+        if minimize and method == "MLHS":
+            raise NotImplementedError(
+                "expected_loss_vs_all(minimize=True) supports method='quad'/'MC'")
 
         # exclude variant
         variants = list(self.models.keys())
@@ -1265,8 +1296,12 @@ class BetaMVTest(BayesMVTest):
             processes = [pool.apply_async(self._rvs, args=(v, ))
                          for v in variants]
             xall = [p.get() for p in processes]
-            maxall = np.maximum.reduce(xall)
 
+            if minimize:
+                minall = np.minimum.reduce(xall)
+                return np.maximum(xvariant - minall - lift, 0).mean()
+
+            maxall = np.maximum.reduce(xall)
             return np.maximum(maxall - xvariant - lift, 0).mean()
         else:
             variant_params = [(self.models[v].alpha_posterior,
@@ -1277,7 +1312,8 @@ class BetaMVTest(BayesMVTest):
 
             if method == "quad":
                 points = get_integration_points(a, b)
-                return integrate.quad(func=func_mv_el, a=0, b=1, points=points, args=(
+                func = func_mv_el_min if minimize else func_mv_el
+                return integrate.quad(func=func, a=0, b=1, points=points, args=(
                     a, b, variant_params))[0]
 
             else:

--- a/cprior/cdist/gamma.py
+++ b/cprior/cdist/gamma.py
@@ -65,6 +65,28 @@ def func_mv_el(x, a, b, variant_params):
     return s * (p - q)
 
 
+def func_mv_el_min(x, a, b, variant_params):
+    """Integrand expected loss integral for the *minimum* direction.
+
+    Mirror of ``func_mv_el`` using the survival function for the others (density
+    of the MIN) and the loss term E[max(V - x, 0)] = E[max(x - V, 0)] + (E[V] - x).
+    """
+    n = len(variant_params)
+
+    aa, bb = map(np.array, zip(*variant_params))
+
+    pdf = np.exp(aa * np.log(bb) + (aa - 1) * np.log(x) - bb * x
+                 - special.gammaln(aa))
+
+    s = np.dot(pdf, [np.prod([special.gammaincc(aa[j], bb[j] * x)
+               for j in range(n) if j != i], axis=0) for i in range(n)])
+
+    p = x * special.gammainc(a, b * x)
+    q = a / b * special.gammainc(a + 1, b * x)
+    mean_v = a / b
+    return s * (p - q + mean_v - x)
+
+
 def func_mv_elr(x, variant_params):
     """Integrand expected loss relative integral."""
     n = len(variant_params)
@@ -1173,7 +1195,7 @@ class GammaMVTest(BayesMVTest):
                 return ppfl - 1, ppfu - 1
 
     def expected_loss_vs_all(self, method="quad", variant="B", lift=0,
-                             mlhs_samples=1000):
+                             mlhs_samples=1000, minimize=False):
         r"""
         Compute the expected loss against all variations. For example, given
         variants "A", "B", "C" and "D", and choosing variant="B", we compute
@@ -1198,6 +1220,11 @@ class GammaMVTest(BayesMVTest):
         mlhs_samples : int (default=1000)
             Number of samples for MLHS method.
 
+        minimize : bool (default=False)
+            If True compute the loss against the *minimum* of all variations,
+            :math:`\mathrm{E}[\max(B - \min(A, C, D), 0)]` — the expected loss
+            for "lower is better" KPIs. Only "MC" and "quad" are supported.
+
         Returns
         -------
         expected_loss_vs_all : float
@@ -1205,6 +1232,9 @@ class GammaMVTest(BayesMVTest):
         check_mv_method(method=method, method_options=("MC", "MLHS", "quad"),
                         control=None, variant=variant,
                         variants=self.models.keys(), lift=lift)
+        if minimize and method == "MLHS":
+            raise NotImplementedError(
+                "expected_loss_vs_all(minimize=True) supports method='quad'/'MC'")
 
         variants = list(self.models.keys())
 
@@ -1220,8 +1250,12 @@ class GammaMVTest(BayesMVTest):
             processes = [pool.apply_async(self._rvs, args=(v, ))
                          for v in variants]
             xall = [p.get() for p in processes]
-            maxall = np.maximum.reduce(xall)
 
+            if minimize:
+                minall = np.minimum.reduce(xall)
+                return np.maximum(xvariant - minall - lift, 0).mean()
+
+            maxall = np.maximum.reduce(xall)
             return np.maximum(maxall - xvariant - lift, 0).mean()
         else:
             n = np.max([self.models[v].ppf(0.99999999) for v in variants])
@@ -1237,7 +1271,8 @@ class GammaMVTest(BayesMVTest):
             b = self.models[variant].rate_posterior
 
             if method == "quad":
-                return integrate.quad(func=func_mv_el, a=0, b=n, args=(
+                func = func_mv_el_min if minimize else func_mv_el
+                return integrate.quad(func=func, a=0, b=n, args=(
                     a, b, variant_params))[0]
             else:
                 r = np.arange(1, mlhs_samples + 1)

--- a/cprior/cdist/normal_inverse_gamma.py
+++ b/cprior/cdist/normal_inverse_gamma.py
@@ -121,6 +121,35 @@ def func_mv_el_mean(x, mu, s, v, variant_params):
     return ((x - mu) * special.stdtr(v, t) - c) * pdf
 
 
+def func_mv_el_mean_min(x, mu, s, v, variant_params):
+    """Integrand expected (mean) loss for the *minimum* direction.
+
+    Mirror of ``func_mv_el_mean``: the others' product uses the Student-t
+    survival (density of the MIN of the others) and the loss term uses
+    E[max(V - x, 0)] = E[max(x - V, 0)] + (E[V] - x), with E[V] = mu.
+    """
+    n = len(variant_params)
+
+    uu, ll, aa, bb = map(np.array, zip(*variant_params))
+
+    vv = 2 * aa
+    ss = np.sqrt(bb / aa / ll)
+    tt = (x - uu) / ss
+
+    pdf = np.exp(-0.5 * (1 + vv) * np.log(1 + tt ** 2 / vv) - 0.5 * np.log(vv)
+                 - np.log(ss) - special.betaln(vv * 0.5, 0.5))
+
+    pdf = np.dot(pdf, [np.prod([1.0 - special.stdtr(vv[j], tt[j])
+                       for j in range(n) if j != i], axis=0)
+                       for i in range(n)])
+
+    t = (x - mu) / s
+    c = s * np.exp(0.5 * (1 - v) * np.log(1 + t ** 2 / v) + 0.5 * np.log(v)
+                   - special.betaln(v * 0.5, 0.5)) / (1 - v)
+
+    return ((x - mu) * special.stdtr(v, t) - c + (mu - x)) * pdf
+
+
 def func_mv_el_var(x, a, b, variant_params):
     """Integrand expected loss integral."""
     n = len(variant_params)
@@ -1877,7 +1906,7 @@ class NormalInverseGammaMVTest(BayesMVTest):
                     [ppfl_var - 1, ppfu_var - 1])
 
     def expected_loss_vs_all(self, method="quad", variant="B", lift=0,
-                             mlhs_samples=1000):
+                             mlhs_samples=1000, minimize=False):
         r"""
         Compute the expected loss against all variations. For example, given
         variants "A", "B", "C" and "D", and choosing variant="B", we compute
@@ -1902,6 +1931,12 @@ class NormalInverseGammaMVTest(BayesMVTest):
         mlhs_samples : int (default=1000)
             Number of samples for MLHS method.
 
+        minimize : bool (default=False)
+            If True compute the loss against the *minimum* of all variations
+            (mean direction reversed) — the expected loss for "lower is better"
+            KPIs. Only the mean is reversed; the variance loss is unchanged.
+            Only "MC" and "quad" are supported.
+
         Returns
         -------
         expected_loss_vs_all : tuple of floats
@@ -1909,6 +1944,9 @@ class NormalInverseGammaMVTest(BayesMVTest):
         check_mv_method(method=method, method_options=("MC", "MLHS", "quad"),
                         control=None, variant=variant,
                         variants=self.models.keys(), lift=lift)
+        if minimize and method == "MLHS":
+            raise NotImplementedError(
+                "expected_loss_vs_all(minimize=True) supports method='quad'/'MC'")
 
         variants = list(self.models.keys())
 
@@ -1924,8 +1962,12 @@ class NormalInverseGammaMVTest(BayesMVTest):
             processes = [pool.apply_async(self._rvs, args=(v, ))
                          for v in variants]
             xall = [p.get() for p in processes]
-            maxall = np.maximum.reduce(xall)
 
+            if minimize:
+                minall = np.minimum.reduce(xall)
+                return np.maximum(xvariant - minall - lift, 0).mean(axis=0)
+
+            maxall = np.maximum.reduce(xall)
             return np.maximum(maxall - xvariant - lift, 0).mean(axis=0)
         else:
             max_ig = np.max([stats.invgamma(
@@ -1965,8 +2007,9 @@ class NormalInverseGammaMVTest(BayesMVTest):
 
             if method == "quad":
                 # mean
+                func_mean = func_mv_el_mean_min if minimize else func_mv_el_mean
                 el_mean = integrate.quad(
-                    func=func_mv_el_mean, a=min_t, b=max_t, args=(
+                    func=func_mean, a=min_t, b=max_t, args=(
                         mu, s, v, variant_params))[0]
 
                 # variance

--- a/cprior/models/normal_adjusted.py
+++ b/cprior/models/normal_adjusted.py
@@ -260,7 +260,8 @@ class NormalAdjustedMVTest(NormalMVTest):
                                            mlhs_samples=mlhs_samples, minimize=minimize)[0]
 
     def expected_loss_vs_all(
-            self, method: str = "quad", variant: str = "B", lift: float = 0, mlhs_samples: int = 1000
+            self, method: str = "quad", variant: str = "B", lift: float = 0, mlhs_samples: int = 1000,
+            minimize: bool = False
     ) -> float:
         """
         Compute the expected loss of a variant against all other variants.
@@ -276,13 +277,17 @@ class NormalAdjustedMVTest(NormalMVTest):
             The amount of uplift.
         mlhs_samples : int, optional (default=1000)
             Number of samples for MLHS method.
+        minimize : bool, optional (default=False)
+            If True compute the loss against the minimum of all variants (mean
+            direction reversed) — for "lower is better" KPIs.
 
         Returns
         -------
         float
             The expected loss of the variant against all other variants.
         """
-        return super().expected_loss_vs_all(method=method, variant=variant, lift=lift, mlhs_samples=mlhs_samples)[0]
+        return super().expected_loss_vs_all(method=method, variant=variant, lift=lift,
+                                            mlhs_samples=mlhs_samples, minimize=minimize)[0]
 
     def expected_loss(
             self, method: str = "exact", control: str = "A", variant: str = "B", lift: float = 0

--- a/tests/test_beta.py
+++ b/tests/test_beta.py
@@ -478,6 +478,22 @@ def test_beta_mv_probability_vs_all_minimize_two_variants():
     assert p_min == approx(1.0 - p_max, rel=1e-6)
 
 
+def test_beta_mv_expected_loss_vs_all_minimize():
+    mvtest = BetaMVTest(
+        {"A": BetaModel(alpha=40, beta=600), "B": BetaModel(alpha=70, beta=900)},
+        1000000, 42)
+
+    # Loss vs the minimum for B == pairwise E[max(B - A, 0)] for two variants.
+    el_min = mvtest.expected_loss_vs_all(method="quad", variant="B", minimize=True)
+    pairwise = mvtest.expected_loss(method="exact", control="B", variant="A")
+    assert el_min == approx(pairwise, rel=1e-6)
+    assert el_min == approx(
+        mvtest.expected_loss_vs_all(method="MC", variant="B", minimize=True), rel=1e-1)
+
+    with raises(NotImplementedError):
+        mvtest.expected_loss_vs_all(method="MLHS", variant="B", minimize=True)
+
+
 def test_beta_mv_expected_loss():
     modelA = BetaModel(alpha=40, beta=60)
     modelB = BetaModel(alpha=70, beta=90)

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -285,6 +285,20 @@ def test_gamma_mv_probability_vs_all_minimize_two_variants():
     assert p_min == approx(1.0 - p_max, rel=1e-6)
 
 
+def test_gamma_mv_expected_loss_vs_all_minimize():
+    mvtest = GammaMVTest(
+        {"A": GammaModel(shape=25, rate=10000), "B": GammaModel(shape=30, rate=10000)},
+        1000000, 42)
+
+    # Loss vs the minimum for B == pairwise E[max(B - A, 0)] for two variants.
+    el_min = mvtest.expected_loss_vs_all(method="quad", variant="B", minimize=True)
+    pairwise = mvtest.expected_loss(method="exact", control="B", variant="A")
+    assert el_min == approx(pairwise, rel=1e-4)
+
+    with raises(NotImplementedError):
+        mvtest.expected_loss_vs_all(method="MLHS", variant="B", minimize=True)
+
+
 def test_gamma_mv_expected_loss():
     modelA = GammaModel(shape=2500, rate=1000000)
     modelB = GammaModel(shape=3000, rate=1000000)

--- a/tests/test_normal_inverse_gamma.py
+++ b/tests/test_normal_inverse_gamma.py
@@ -425,6 +425,23 @@ def test_normal_inverse_gamma_mv_probability_vs_all_minimize():
     assert sum(p_min_mean) == approx(1.0, rel=1e-6)
 
 
+def test_normal_inverse_gamma_mv_expected_loss_vs_all_minimize():
+    models = {
+        "A": NormalInverseGammaModel(loc=5.5, variance_scale=3, shape=14, scale=5),
+        "B": NormalInverseGammaModel(loc=6.0, variance_scale=4, shape=12, scale=9),
+    }
+    mvtest = NormalInverseGammaMVTest(models, 1000000)
+
+    # Mean loss vs the minimum for B == pairwise mean E[max(B - A, 0)].
+    el_min_mean = mvtest.expected_loss_vs_all(
+        method="quad", variant="B", minimize=True)[0]
+    pairwise_mean = mvtest.expected_loss(method="exact", control="B", variant="A")[0]
+    assert el_min_mean == approx(pairwise_mean, rel=1e-4)
+
+    with raises(NotImplementedError):
+        mvtest.expected_loss_vs_all(method="MLHS", variant="B", minimize=True)
+
+
 def test_normal_inverse_gamma_mv_expected_loss():
     modelA = NormalInverseGammaModel(loc=5.5, variance_scale=3, shape=14,
                                      scale=5)


### PR DESCRIPTION
## Why

Follow-up to #11 (`probability_vs_all(minimize=...)`). For "lower is better" KPIs the expected-loss columns must be computed against the **minimum** of the variants, not the maximum.

## What

Adds `minimize=False` to `expected_loss_vs_all` on `BetaMVTest`, `GammaMVTest` (→ `PoissonMVTest`) and `NormalInverseGammaMVTest` / `NormalAdjustedMVTest`. When True it computes `E[max(B − min(others), 0)]`.

New `func_mv_el_min` integrands (Beta / Gamma / NormalInverseGamma-mean) use the **survival** product for the others (density of the minimum) and the identity `E[max(V − x, 0)] = E[max(x − V, 0)] + (E[V] − x)`. For the normal model only the mean direction is reversed; the variance loss is unchanged.

Supported for `method='quad'` (production) and `'MC'`; `'MLHS' + minimize` raises `NotImplementedError`.

## Verification

New tests assert, per family:
- 2-variant `expected_loss_vs_all(min, B)` == pairwise `E[max(B − A, 0)]` exactly
- `quad` ≈ `MC`
- `MLHS + minimize` raises

3-variant spot check: min-loss is smallest for the lowest-mean variant and mirrors the max-direction loss. Existing max-direction paths unchanged.